### PR TITLE
comment for mac users

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ Just import it in your project's index.js:
 ```js
 require('react-native-ssb-shims');
 ```
+
+### Note
+Mac users: in order to get the post-install scripts to run, you will first need to install `coreutils` through homebrew
+```brew install coreutils```


### PR DESCRIPTION
context for this:
the post install scripts call 
``` realpath ``` which isn't defined on mac machines without coreutils